### PR TITLE
Uses the AUSF ROCK instead of the upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ juju deploy sdcore-ausf --trust --channel=edge
 
 ## Image
 
-- **ausf**: `omecproject/5gc-ausf:master-c84dff4`
+- **ausf**: `ghcr.io/canonical/sdcore-ausf:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   ausf-image:
     type: oci-image
     description: OCI image for 5G ausf
-    upstream-source: omecproject/5gc-ausf:master-c84dff4
+    upstream-source: ghcr.io/canonical/sdcore-ausf:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -196,7 +196,7 @@ class AUSFOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"/free5gc/ausf/ausf --ausfcfg {CONFIG_DIR}/{CONFIG_FILE_NAME}",  # noqa: E501
+                        "command": f"/bin/ausf --ausfcfg {CONFIG_DIR}/{CONFIG_FILE_NAME}",  # noqa: E501
                         "environment": self._ausf_environment_variables,
                     },
                 },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -150,7 +150,7 @@ class TestCharm(unittest.TestCase):
                 "ausf": {
                     "startup": "enabled",
                     "override": "replace",
-                    "command": "/free5gc/ausf/ausf --ausfcfg /free5gc/config/ausfcfg.conf",
+                    "command": "/bin/ausf --ausfcfg /free5gc/config/ausfcfg.conf",
                     "environment": {
                         "GOTRACEBACK": "crash",
                         "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
@@ -244,7 +244,7 @@ class TestCharm(unittest.TestCase):
                     "ausf": {
                         "startup": "enabled",
                         "override": "replace",
-                        "command": "/free5gc/ausf/ausf --ausfcfg /free5gc/config/ausfcfg.conf",
+                        "command": "/bin/ausf --ausfcfg /free5gc/config/ausfcfg.conf",
                         "environment": {
                             "GOTRACEBACK": "crash",
                             "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
@@ -291,7 +291,7 @@ class TestCharm(unittest.TestCase):
                     "ausf": {
                         "startup": "enabled",
                         "override": "replace",
-                        "command": "/free5gc/ausf/ausf --ausfcfg /free5gc/config/ausfcfg.conf",
+                        "command": "/bin/ausf --ausfcfg /free5gc/config/ausfcfg.conf",
                         "environment": {
                             "GOTRACEBACK": "crash",
                             "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",


### PR DESCRIPTION
# Description

Don't merge before the [ROCK](https://github.com/canonical/sdcore-ausf-rock/pull/1) is merged.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library