### PR TITLE
(Fix) Adding rust compiler to fix pydantic compilation

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,11 @@ bases:
 
 parts:
   charm:
+    build-packages:
+      - cargo
+      - rustc
     charm-binary-python-packages:
-    - cryptography
-    - jsonschema
+      - cryptography
+      - jsonschema
+      - pip
+      - setuptools

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -39,7 +39,7 @@ class TestCharm(unittest.TestCase):
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
 
         self.assertEqual(
-            state_out.status.unit,
+            state_out.unit_status,
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
@@ -56,7 +56,7 @@ class TestCharm(unittest.TestCase):
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
 
         self.assertEqual(
-            state_out.status.unit,
+            state_out.unit_status,
             WaitingStatus("Waiting for NRF data to be available"),
         )
         self.assertEqual(
@@ -76,7 +76,7 @@ class TestCharm(unittest.TestCase):
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
 
         self.assertEqual(
-            state_out.status.unit,
+            state_out.unit_status,
             WaitingStatus("Waiting for storage to be attached"),
         )
         self.assertEqual(
@@ -196,7 +196,7 @@ class TestCharm(unittest.TestCase):
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
         self.assertEqual(
-            state_out.status.unit,
+            state_out.unit_status,
             ActiveStatus(),
         )
 
@@ -219,7 +219,7 @@ class TestCharm(unittest.TestCase):
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
         self.assertEqual(
-            state_out.status.unit,
+            state_out.unit_status,
             WaitingStatus("Waiting for pod IP address to be available"),
         )
 
@@ -348,7 +348,7 @@ class TestCharm(unittest.TestCase):
         state_out = self.ctx.run(self.nrf_relation.changed_event, state_in)
 
         self.assertEqual(
-            state_out.status.unit,
+            state_out.unit_status,
             WaitingStatus("Waiting for container to start"),
         )
         self.assertEqual(


### PR DESCRIPTION
# Description

Adds dependencies needed to properly compile new version of `pydantic`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library