### PR TITLE
(TELCO-574) Block charm when NRF goes down

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==2.4.1
 lightkube
 lightkube-models
 pydantic

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,7 @@ class AUSFOperatorCharm(CharmBase):
         self.framework.observe(self.on.ausf_pebble_ready, self._configure_ausf)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_ausf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_ausf)
+        self.framework.observe(self._nrf_requires.on.nrf_broken, self._on_nrf_broken)
 
         self.framework.observe(
             self.on.certificates_relation_created, self._on_certificates_relation_created
@@ -162,6 +163,14 @@ class AUSFOperatorCharm(CharmBase):
             logger.debug("Expiring certificate is not the one stored")
             return
         self._request_new_certificate()
+
+    def _on_nrf_broken(self, event: EventBase) -> None:
+        """Event handler for NRF relation broken.
+
+        Args:
+            event (NRFBrokenEvent): Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
 
     def _generate_private_key(self) -> None:
         """Generates and stores private key."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -100,4 +100,4 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
         relation1=f"{NRF_APPLICATION_NAME}:database", relation2=DB_APPLICATION_NAME
     )
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=300)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +21,8 @@ NRF_APPLICATION_NAME = "sdcore-nrf"
 TLS_PROVIDER_NAME = "self-signed-certificates"
 
 
-async def _deploy_mongodb(ops_test):
-    await ops_test.model.deploy(
+async def _deploy_mongodb(ops_test: OpsTest):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         DB_APPLICATION_NAME,
         application_name=DB_APPLICATION_NAME,
         channel="5/edge",
@@ -29,21 +30,21 @@ async def _deploy_mongodb(ops_test):
     )
 
 
-async def _deploy_sdcore_nrf_operator(ops_test):
+async def _deploy_sdcore_nrf_operator(ops_test: OpsTest):
     await _deploy_mongodb(ops_test)
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         NRF_APPLICATION_NAME,
         application_name=NRF_APPLICATION_NAME,
         channel="edge",
         trust=True,
     )
-    await ops_test.model.add_relation(
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME
     )
 
 
-async def _deploy_tls_provider(ops_test):
-    await ops_test.model.deploy(
+async def _deploy_tls_provider(ops_test: OpsTest):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         TLS_PROVIDER_NAME,
         application_name=TLS_PROVIDER_NAME,
         channel="edge",
@@ -52,7 +53,7 @@ async def _deploy_tls_provider(ops_test):
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
-async def build_and_deploy(ops_test):
+async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
     deploy_nrf = asyncio.create_task(_deploy_sdcore_nrf_operator(ops_test))
     deploy_tls_provider = asyncio.create_task(_deploy_tls_provider(ops_test))
@@ -62,7 +63,7 @@ async def build_and_deploy(ops_test):
     resources = {
         "ausf-image": METADATA["resources"]["ausf-image"]["upstream-source"],
     }
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         charm,
         resources=resources,
         application_name=APP_NAME,
@@ -71,14 +72,32 @@ async def build_and_deploy(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_relate_and_wait_for_active_status(
-    ops_test,
-    build_and_deploy,
-):
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=TLS_PROVIDER_NAME)
-    await ops_test.model.wait_for_idle(
+async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.add_relation(relation1=APP_NAME, relation2=TLS_PROVIDER_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APP_NAME],
         status="active",
         timeout=1000,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.remove_application(NRF_APPLICATION_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        NRF_APPLICATION_NAME,
+        application_name=NRF_APPLICATION_NAME,
+        channel="edge",
+        trust=True,
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=f"{NRF_APPLICATION_NAME}:database", relation2=DB_APPLICATION_NAME
+    )
+    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=60)  # type: ignore[union-attr]  # noqa: E501


### PR DESCRIPTION
# Description

This PR adds handling of the NRF relation broken event.
If NRF will ever go down, the AUSF charm will reflect that fact by going into `Blocked` state.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library