### PR TITLE
Enforce TLS Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ juju deploy sdcore-ausf --trust --channel=edge
 juju deploy sdcore-nrf --trust --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
 juju deploy self-signed-certificates --channel=beta
-juju integrate sdcore-ausf:fiveg-nrf sdcore-nrf:fiveg-nrf
 juju integrate sdcore-nrf:database mongodb-k8s
+juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
+juju integrate sdcore-ausf:fiveg-nrf sdcore-nrf:fiveg-nrf
 juju integrate sdcore-ausf:certificates self-signed-certificates:certificates
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,10 @@ A Charmed Operator for SD-Core's Authentication Server Function (AUSF) component
 ```bash
 juju deploy sdcore-ausf --trust --channel=edge
 juju deploy sdcore-nrf --trust --channel=edge
-juju integrate sdcore-ausf:fiveg-nrf sdcore-nrf:fiveg-nrf
 juju deploy mongodb-k8s --trust --channel=5/edge
+juju deploy self-signed-certificates --channel=beta
+juju integrate sdcore-ausf:fiveg-nrf sdcore-nrf:fiveg-nrf
 juju integrate sdcore-nrf:database mongodb-k8s
-```
-
-## Optional
-
-```bash
-juju deploy self-signed-certificates --channel=edge
 juju integrate sdcore-ausf:certificates self-signed-certificates:certificates
 ```
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,9 +94,10 @@ class AUSFOperatorCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for container to start")
             event.defer()
             return
-        if not self._relation_created("fiveg_nrf"):
-            self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
-            return
+        for relation in ["fiveg_nrf", "certificates"]:
+            if not self._relation_created(relation):
+                self.unit.status = BlockedStatus(f"Waiting for {relation} relation")
+                return
         if not self._nrf_data_is_available:
             self.unit.status = WaitingStatus("Waiting for NRF data to be available")
             event.defer()
@@ -107,6 +108,10 @@ class AUSFOperatorCharm(CharmBase):
             return
         if not _get_pod_ip():
             self.unit.status = WaitingStatus("Waiting for pod IP address to be available")
+            event.defer()
+            return
+        if not self._certificate_is_stored():
+            self.unit.status = WaitingStatus("Waiting for certificates to be stored")
             event.defer()
             return
         config_file_changed = self._apply_ausf_config()
@@ -128,7 +133,7 @@ class AUSFOperatorCharm(CharmBase):
         self._delete_private_key()
         self._delete_csr()
         self._delete_certificate()
-        self._configure_ausf(event)
+        self.unit.status = BlockedStatus("Waiting for certificates relation")
 
     def _on_certificates_relation_joined(self, event: EventBase) -> None:
         """Generates CSR and requests new certificate."""
@@ -264,7 +269,7 @@ class AUSFOperatorCharm(CharmBase):
             ausf_ip=_get_pod_ip(),  # type: ignore[arg-type]
             nrf_url=self._nrf_requires.nrf_url,
             sbi_port=SBI_PORT,
-            scheme="https" if self._certificate_is_stored() else "http",
+            scheme="https",
         )
         if not self._config_file_content_matches(content):
             self._push_config_file(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,6 +41,8 @@ async def _deploy_sdcore_nrf_operator(ops_test: OpsTest):
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME
     )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
 
 
 async def _deploy_tls_provider(ops_test: OpsTest):
@@ -58,8 +60,8 @@ async def build_and_deploy(ops_test: OpsTest):
     deploy_nrf = asyncio.create_task(_deploy_sdcore_nrf_operator(ops_test))
     deploy_tls_provider = asyncio.create_task(_deploy_tls_provider(ops_test))
     charm = await ops_test.build_charm(".")
-    await deploy_nrf
     await deploy_tls_provider
+    await deploy_nrf
     resources = {
         "ausf-image": METADATA["resources"]["ausf-image"]["upstream-source"],
     }
@@ -99,6 +101,7 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{NRF_APPLICATION_NAME}:database", relation2=DB_APPLICATION_NAME
     )
+    await ops_test.model.add_relation(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -42,7 +42,8 @@ async def _deploy_sdcore_nrf_operator(ops_test: OpsTest):
         relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME
     )
     await ops_test.model.add_relation(  # type: ignore[union-attr]
-        relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
+        relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME
+    )
 
 
 async def _deploy_tls_provider(ops_test: OpsTest):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -47,7 +47,7 @@ async def _deploy_tls_provider(ops_test: OpsTest):
     await ops_test.model.deploy(  # type: ignore[union-attr]
         TLS_PROVIDER_NAME,
         application_name=TLS_PROVIDER_NAME,
-        channel="edge",
+        channel="beta",
     )
 
 
@@ -100,4 +100,24 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
         relation1=f"{NRF_APPLICATION_NAME}:database", relation2=DB_APPLICATION_NAME
     )
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APPLICATION_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_tls_and_wait_for_blocked_status(ops_test, build_and_deploy):
+    await ops_test.model.remove_application(TLS_PROVIDER_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_tls_and_wait_for_active_status(ops_test, build_and_deploy):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        TLS_PROVIDER_NAME,
+        application_name=TLS_PROVIDER_NAME,
+        channel="beta",
+        trust=True,
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=APP_NAME, relation2=TLS_PROVIDER_NAME
+    )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -5,7 +5,7 @@ configuration:
     bindingIPv4: 0.0.0.0
     port: 29509
     registerIPv4: 1.1.1.1
-    scheme: http
+    scheme: https
   serviceNameList:
     - nausf-auth
 info:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -66,6 +66,29 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
+    @patch("charm.check_output")
+    def test_given_ausf_charm_in_active_status_when_certificates_relation_breaks_then_status_is_blocked(  # noqa: E501
+        self, patch_check_output
+    ):
+        config_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+        )
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
+            unit_status=ActiveStatus(),
+        )
+        patch_check_output.return_value = "1.1.1.1".encode()
+
+        state_out = self.ctx.run(self.tls_relation.broken_event, state_in)
+
+        self.assertEqual(
+            state_out.unit_status,
+            BlockedStatus("Waiting for certificates relation"),
+        )
+
     def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(
         self,
     ):
@@ -73,7 +96,7 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[self.container],
-            relations=[nrf_relation],
+            relations=[nrf_relation, self.tls_relation],
         )
 
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
@@ -93,7 +116,7 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[self.container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
 
         state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
@@ -108,7 +131,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    def test_given_relations_created_and_nrf_data_available_when_pebble_ready_then_config_file_rendered_and_pushed(  # noqa: E501
+    def test_given_relation_created_and_nrf_data_available_and_certificates_not_stored_when_pebble_ready_then_status_is_waiting(  # noqa: E501
         self,
         patch_check_output,
     ):
@@ -119,9 +142,39 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
+        )
+
+        patch_check_output.return_value = b"1.1.1.1"
+        state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
+
+        self.assertEqual(
+            state_out.unit_status,
+            WaitingStatus("Waiting for certificates to be stored"),
+        )
+        self.assertEqual(
+            state_out.deferred[0].name,
+            "ausf_pebble_ready",
+        )
+
+    @patch("ops.model.Container.exists")
+    @patch("charm.check_output")
+    def test_given_relations_created_and_nrf_data_available_and_certificate_stored_when_pebble_ready_then_config_file_rendered_and_pushed(  # noqa: E501
+        self,
+        patch_check_output,
+        patch_exists,
+    ):
+        config_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={"config_dir": Mount("/free5gc/config", config_dir.name)},
+        )
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = b"1.1.1.1"
+        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -133,10 +186,12 @@ class TestCharm(unittest.TestCase):
             expected_content = expected.read().strip()
             self.assertEqual(actual_content, expected_content)
 
+    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_config_pushed_but_content_changed_when_pebble_ready_then_new_config_content_is_pushed(  # noqa: E501
         self,
         patch_check_output,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -145,9 +200,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
         with open(Path(config_dir.name) / "ausfcfg.conf", "w") as existing_config:
             existing_config.write("never gonna give you up")
 
@@ -161,10 +217,12 @@ class TestCharm(unittest.TestCase):
             expected_content = expected.read().strip()
             self.assertEqual(actual_content, expected_content)
 
+    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_given_relation_available_and_config_pushed_when_pebble_ready_then_pebble_layer_is_added_correctly(  # noqa: E501
         self,
         patch_check_output,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -173,9 +231,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -200,10 +259,12 @@ class TestCharm(unittest.TestCase):
         updated_plan = state_out.containers[0].layers["ausf"]
         self.assertEqual(expected_plan, updated_plan)
 
+    @patch("ops.model.Container.exists")
     @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_status_is_active(  # noqa: E501
         self,
         patch_check_output,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -212,9 +273,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         state_out = self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -235,7 +297,7 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "".encode()
 
@@ -246,12 +308,14 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for pod IP address to be available"),
         )
 
+    @patch("ops.model.Container.exists")
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_service_is_restarted(  # noqa: E501
         self,
         patch_check_output,
         patch_restart,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         container = self.container.replace(
@@ -260,9 +324,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 
@@ -315,12 +380,14 @@ class TestCharm(unittest.TestCase):
 
         patch_restart.assert_not_called()
 
+    @patch("ops.model.Container.exists")
     @patch("ops.model.Container.restart")
     @patch("charm.check_output")
     def test_config_pushed_but_content_changed_and_layer_already_applied_when_pebble_ready_then_ausf_service_is_restarted(  # noqa: E501
         self,
         patch_check_output,
         patch_restart,
+        patch_exists,
     ):
         config_dir = tempfile.TemporaryDirectory()
         applied_plan = Layer(
@@ -350,9 +417,10 @@ class TestCharm(unittest.TestCase):
         state_in = State(
             leader=True,
             containers=[container],
-            relations=[self.nrf_relation],
+            relations=[self.nrf_relation, self.tls_relation],
         )
         patch_check_output.return_value = "1.1.1.1".encode()
+        patch_exists.return_value = True
 
         self.ctx.run(container.pebble_ready_event, state_in)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -43,6 +43,22 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
+    def test_given_certificates_relation_not_created_when_pebble_ready_then_status_is_blocked(
+        self,
+    ):
+        state_in = State(
+            leader=True,
+            containers=[self.container],
+            relations=[self.nrf_relation],
+        )
+
+        state_out = self.ctx.run(self.container.pebble_ready_event, state_in)
+
+        self.assertEqual(
+            state_out.unit_status,
+            BlockedStatus("Waiting for certificates relation"),
+        )
+
     @patch("charm.check_output")
     def test_given_ausf_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
         self, patch_check_output


### PR DESCRIPTION
# Description

Enforces TLS integration in the charm. Charm remains in blocked state until the 'certificates' relation is created, and in waiting status until a certificate is stored.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library