### PR TITLE
Update website link in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,7 @@ display-name: SD-Core 5G AUSF
 summary: A Charmed Operator for SD-Core's AUSF component.
 description: |
   A Charmed Operator for SD-Core's Authentication Server Function (AUSF) component.
-website: https://charmhub.io/sdcore-ausf
+website: https://github.com/canonical/sdcore-ausf-operator # Once Charmhub supports the `source` link, this could be changed.
 source: https://github.com/canonical/sdcore-ausf-operator
 issues: https://github.com/canonical/sdcore-ausf-operator/issues
 


### PR DESCRIPTION
Points to the github website for two reasons:

1. The `source` entry isn't used by charmhub
2. The `website` entry is used to display a link on the `charmhub` website, and there is no need for Charmhub to point back to itself.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library