### PR TITLE
fix: Checks if certificate is already requested

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -149,9 +149,10 @@ class AUSFOperatorCharm(CharmBase):
         if not self._private_key_is_stored():
             event.defer()
             return
-        if not self._certificate_is_stored():
-            self._request_new_certificate()
+        if self._certificate_is_stored():
             return
+
+        self._request_new_certificate()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Pushes certificate to workload and configures workload."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -149,7 +149,9 @@ class AUSFOperatorCharm(CharmBase):
         if not self._private_key_is_stored():
             event.defer()
             return
-        self._request_new_certificate()
+        if not self._certificate_is_stored():
+            self._request_new_certificate()
+            return
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Pushes certificate to workload and configures workload."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -549,7 +549,7 @@ class TestCharm(unittest.TestCase):
         "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
     )
     @patch("charm.generate_csr")
-    def test_given_private_key_exists_when_on_certificates_relation_joined_then_cert_is_requested(
+    def test_given_private_key_exists_and_certificate_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
         self,
         patch_generate_csr,
         patch_request_certificate_creation,
@@ -571,6 +571,36 @@ class TestCharm(unittest.TestCase):
         self.ctx.run(self.tls_relation.joined_event, state_in)
 
         patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
+
+    @patch(
+        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
+    )
+    @patch("ops.model.Container.exists")
+    @patch("charm.generate_csr")
+    def test_given_certificate_already_requested_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
+        self,
+        patch_generate_csr,
+        patch_exists,
+        patch_request_certificate_creation,
+    ):
+        cert_dir = tempfile.TemporaryDirectory()
+        container = self.container.replace(
+            mounts={"cert_dir": Mount("/support/TLS", cert_dir.name)},
+        )
+        with open(Path(cert_dir.name) / "ausf.key", "w") as ausf_key_file:
+            ausf_key_file.write("never gonna run around and desert you")
+        csr = b"whatever csr content"
+        patch_generate_csr.return_value = csr
+        patch_exists.return_value = True
+        state_in = State(
+            leader=True,
+            containers=[container],
+            relations=[self.nrf_relation, self.tls_relation],
+        )
+
+        self.ctx.run(self.tls_relation.joined_event, state_in)
+
+        patch_request_certificate_creation.assert_not_called()
 
     @patch("charm.check_output")
     def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(


### PR DESCRIPTION
# Description

Adds a guard in the certificates relation joined handler to check if the cert was already stored before requesting a new one.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library