### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-ausf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-ausf-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-ausf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-ausf-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core AUSF Operator for K8s
+# SD-Core AUSF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-ausf-k8s/badge.svg)](https://charmhub.io/sdcore-ausf-k8s)
 
 A Charmed Operator for SD-Core's Authentication Server Function (AUSF) component for K8s. 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# SD-Core AUSF Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-ausf/badge.svg)](https://charmhub.io/sdcore-ausf)
+# SD-Core AUSF K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-ausf-k8s/badge.svg)](https://charmhub.io/sdcore-ausf-k8s)
 
-A Charmed Operator for SD-Core's Authentication Server Function (AUSF) component. 
+A Charmed K8s Operator for SD-Core's Authentication Server Function (AUSF) component. 
 
 ## Usage
 
 ```bash
-juju deploy sdcore-ausf --channel=edge
-juju deploy sdcore-nrf --channel=edge
+juju deploy sdcore-ausf-k8s --channel=edge
+juju deploy sdcore-nrf-k8s --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
 juju deploy self-signed-certificates --channel=beta
-juju integrate sdcore-nrf:database mongodb-k8s
-juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
-juju integrate sdcore-ausf:fiveg-nrf sdcore-nrf:fiveg-nrf
-juju integrate sdcore-ausf:certificates self-signed-certificates:certificates
+juju integrate sdcore-nrf-k8s:database mongodb-k8s
+juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-ausf-k8s:fiveg-nrf sdcore-nrf-k8s:fiveg-nrf
+juju integrate sdcore-ausf-k8s:certificates self-signed-certificates:certificates
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core AUSF K8s Operator
+# SD-Core AUSF Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-ausf-k8s/badge.svg)](https://charmhub.io/sdcore-ausf-k8s)
 
-A Charmed K8s Operator for SD-Core's Authentication Server Function (AUSF) component. 
+A Charmed Operator for SD-Core's Authentication Server Function (AUSF) component for K8s. 
 
 ## Usage
 

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -13,7 +13,7 @@ NRF information and another charm requiring this information.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_nrf.v0.fiveg_nrf
+charmcraft fetch-lib charms.sdcore_nrf_k8s.v0.fiveg_nrf
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -28,7 +28,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):
@@ -103,14 +103,14 @@ from ops.model import Relation
 from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "cd132a12c2b34243bfd2bae8d08c32d6"
+LIBID = "14746bb6f8d34accbeac27ea50ff4715"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-ausf
+name: sdcore-ausf-k8s
 
-display-name: SD-Core 5G AUSF
+display-name: SD-Core 5G AUSF K8s
 summary: A Charmed Operator for SD-Core's AUSF component.
 description: |
   A Charmed Operator for SD-Core's Authentication Server Function (AUSF) component.
-website: https://github.com/canonical/sdcore-ausf-operator # Once Charmhub supports the `source` link, this could be changed.
-source: https://github.com/canonical/sdcore-ausf-operator
-issues: https://github.com/canonical/sdcore-ausf-operator/issues
+website: https://charmhub.io/sdcore-ausf-k8s
+source: https://github.com/canonical/sdcore-ausf-k8s-operator
+issues: https://github.com/canonical/sdcore-ausf-k8s-operator/issues
 
 containers:
   ausf:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core AUSF service."""
+"""Charmed K8s operator for the SD-Core AUSF service."""
 
 import logging
 from ipaddress import IPv4Address
@@ -38,8 +38,8 @@ CERTIFICATE_NAME = "ausf.pem"
 CERTIFICATE_COMMON_NAME = "ausf.sdcore"
 
 
-class AUSFOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core AUSF operator."""
+class AUSFK8sOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core AUSF K8s operator."""
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
@@ -422,4 +422,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(AUSFOperatorCharm)
+    main(AUSFK8sOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the SD-Core AUSF service."""
+"""Charmed operator for the SD-Core AUSF service for K8s."""
 
 import logging
 from ipaddress import IPv4Address
@@ -38,8 +38,8 @@ CERTIFICATE_NAME = "ausf.pem"
 CERTIFICATE_COMMON_NAME = "ausf.sdcore"
 
 
-class AUSFK8sOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core AUSF K8s operator."""
+class AUSFOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core AUSF operator for K8s."""
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
@@ -422,4 +422,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(AUSFK8sOperatorCharm)
+    main(AUSFOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,7 @@ from ipaddress import IPv4Address
 from subprocess import check_output
 from typing import Optional
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateAvailableEvent,
     CertificateExpiringEvent,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,7 +19,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 DB_APPLICATION_NAME = "mongodb-k8s"
-NRF_APPLICATION_NAME = "sdcore-nrf"
+NRF_APPLICATION_NAME = "sdcore-nrf-k8s"
 TLS_PROVIDER_NAME = "self-signed-certificates"
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,12 +13,12 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer
 from scenario import Container, Context, Mount, Relation, State  # type: ignore[import]
 
-from charm import AUSFOperatorCharm
+from charm import AUSFK8sOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.ctx = Context(AUSFOperatorCharm)
+        self.ctx = Context(AUSFK8sOperatorCharm)
         self.container = Container(name="ausf", can_connect=True)
         self.nrf_relation = Relation(
             endpoint="fiveg_nrf",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,12 +13,12 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer
 from scenario import Container, Context, Mount, Relation, State  # type: ignore[import]
 
-from charm import AUSFK8sOperatorCharm
+from charm import AUSFOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.ctx = Context(AUSFK8sOperatorCharm)
+        self.ctx = Context(AUSFOperatorCharm)
         self.container = Container(name="ausf", can_connect=True)
         self.nrf_relation = Relation(
             endpoint="fiveg_nrf",


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

- Fetch new fiveg_nrf library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library